### PR TITLE
feat(themes): add banner_message and banner_dismissible fields

### DIFF
--- a/db/migrate/20260331120000_add_banner_fields_to_themes.rb
+++ b/db/migrate/20260331120000_add_banner_fields_to_themes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+# typed: false
+
+class AddBannerFieldsToThemes < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL.squish
+      ALTER TABLE themes_translations ADD COLUMN IF NOT EXISTS banner_message text;
+      ALTER TABLE themes ADD COLUMN IF NOT EXISTS banner_dismissible boolean DEFAULT true;
+
+      INSERT INTO directus_fields (id, collection, field, interface, options, display, display_options, readonly, hidden, sort, width, translations, note, conditions, required, "group", validation, validation_message)
+      VALUES
+        (619, 'themes_translations', 'banner_message', 'input-rich-text-html', NULL, NULL, NULL, false, false, 10, 'full', NULL, NULL, NULL, false, NULL, NULL, NULL),
+        (620, 'themes', 'banner_dismissible', 'boolean', NULL, NULL, NULL, false, false, 13, 'full', NULL, NULL, NULL, false, NULL, NULL, NULL)
+      ;
+    SQL
+  end
+end

--- a/docker/directus/data.sql
+++ b/docker/directus/data.sql
@@ -332,6 +332,8 @@ COPY public.directus_fields (id, collection, field, special, interface, options,
 616	fields	json_schema	cast-json	input-code	\N	\N	\N	f	t	\N	full	\N	\N	\N	f	\N	\N	\N
 617	sources	extends_source_id	\N	select-dropdown-m2o	{"filter":{"_and":[{"project_id":{"_in":["$CURRENT_USER.project_id","{{project_id}}"]}}]},"template":"{{slug}}","enableCreate":false}	related-values	{"template":"{{slug}}"}	f	f	\N	full	\N	\N	\N	f	\N	\N	\N
 618	menu_items	icon_show	\N	select-dropdown	{"choices":[{"text":"always","value":"always","icon":"check_box"},{"text":"never","value":"never","icon":"check_box_outline_blank"}]}	\N	\N	f	f	11	full	\N	\N	\N	f	category	\N	\N
+619	themes_translations	banner_message	\N	input-rich-text-html	\N	\N	\N	f	f	10	full	\N	\N	\N	f	\N	\N	\N
+620	themes	banner_dismissible	cast-boolean	boolean	\N	\N	\N	f	f	13	full	\N	\N	\N	f	\N	\N	\N
 \.
 
 
@@ -702,7 +704,7 @@ SELECT pg_catalog.setval('public.directus_activity_id_seq', 1, true);
 -- Name: directus_fields_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.directus_fields_id_seq', 619, true);
+SELECT pg_catalog.setval('public.directus_fields_id_seq', 620, true);
 
 --
 -- Name: directus_notifications_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres

--- a/docker/directus/schema.sql
+++ b/docker/directus/schema.sql
@@ -1665,7 +1665,8 @@ CREATE TABLE public.themes (
     google_site_verification character varying(255),
     google_tag_manager_id character varying(255),
     cookies_usage_detail_url character varying(255),
-    report_issue boolean DEFAULT false
+    report_issue boolean DEFAULT false,
+    banner_dismissible boolean DEFAULT true
 );
 
 
@@ -1734,7 +1735,8 @@ CREATE TABLE public.themes_translations (
     site_url character varying(255),
     main_url character varying(255),
     keywords character varying(255),
-    cookies_consent_message text
+    cookies_consent_message text,
+    banner_message text
 );
 
 

--- a/lib/api-02.sql
+++ b/lib/api-02.sql
@@ -91,7 +91,9 @@ SELECT
     nullif(jsonb_strip_nulls(jsonb_object_agg(substring(trans.languages_code, 1, 2), trans.site_url) FILTER (WHERE trans.languages_code IS NOT NULL)), '{}'::jsonb) AS site_url,
     nullif(jsonb_strip_nulls(jsonb_object_agg(substring(trans.languages_code, 1, 2), trans.main_url) FILTER (WHERE trans.languages_code IS NOT NULL)), '{}'::jsonb) AS main_url,
     nullif(jsonb_strip_nulls(jsonb_object_agg(substring(trans.languages_code, 1, 2), trans.keywords) FILTER (WHERE trans.languages_code IS NOT NULL)), '{}'::jsonb) AS keywords,
-    nullif(jsonb_strip_nulls(jsonb_object_agg(substring(trans.languages_code, 1, 2), trans.cookies_consent_message) FILTER (WHERE trans.languages_code IS NOT NULL)), '{}'::jsonb) AS cookies_consent_message
+    nullif(jsonb_strip_nulls(jsonb_object_agg(substring(trans.languages_code, 1, 2), trans.cookies_consent_message) FILTER (WHERE trans.languages_code IS NOT NULL)), '{}'::jsonb) AS cookies_consent_message,
+    nullif(jsonb_strip_nulls(jsonb_object_agg(substring(trans.languages_code, 1, 2), trans.banner_message) FILTER (WHERE trans.languages_code IS NOT NULL)), '{}'::jsonb) AS banner_message,
+    themes.banner_dismissible
 FROM
     themes
     LEFT JOIN themes_translations AS trans ON
@@ -290,7 +292,9 @@ CREATE OR REPLACE FUNCTION projects(
                                 'google_site_verification', themes.google_site_verification,
                                 'google_tag_manager_id', themes.google_tag_manager_id,
                                 'cookies_consent_message', themes.cookies_consent_message,
-                                'cookies_usage_detail_url', themes.cookies_usage_detail_url
+                                'cookies_usage_detail_url', themes.cookies_usage_detail_url,
+                                'banner_message', themes.banner_message,
+                                'banner_dismissible', themes.banner_dismissible
                             )
                         ))
                     FROM

--- a/public/static/elasa-0.2.swagger.yaml
+++ b/public/static/elasa-0.2.swagger.yaml
@@ -1074,6 +1074,12 @@ components:
               cookies_usage_detail_url:
                 type: string
                 description: URL of the cookies policy page.
+              banner_message:
+                $ref: '#/components/schemas/multilingual_string'
+                description: HTML content for the banner (supports inline styles).
+              banner_dismissible:
+                type: boolean
+                description: Whether the banner can be dismissed by the user.
 
   parameters:
     param_path_project:


### PR DESCRIPTION
Closes #38

## Changes

- DB migration: add `banner_message` (text) to `themes_translations`, `banner_dismissible` (boolean) to `themes`
- `lib/api-02.sql`: aggregate `banner_message` in `themes_join` view; expose both fields in `projects()` output
- Directus fields config: UI fields for both new columns
- `docker/directus/data.sql` + `schema.sql`: updated init data
- `elasa-0.2.swagger.yaml`: both fields added to theme schema

See Vido PR: teritorio/vido#861